### PR TITLE
Image alt

### DIFF
--- a/myoperations.py
+++ b/myoperations.py
@@ -190,7 +190,7 @@ def mytransform_xml(text):
     # good indentation and spacing
     # note that re assumes no carriage returns in the image tag
     thetext = re.sub(r'(\n *)<image ([^>]*)alt="([^"]+)"([^>]*)/>',
-                     r'\1<image \2\4/>\1  <description>\1    \3\1  </description>\1</image>', thetext)
+                     r'\1<image \2\4>\1  <description>\1    \3\1  </description>\1</image>', thetext)
     thetext = re.sub(r'<image ([^>]*)alt="([^"]+)"([^>]*)/>',
                      r'<image \1\3><description>\2</description></image>', thetext)
 
@@ -198,11 +198,11 @@ def mytransform_xml(text):
     thetext = re.sub(r'" +>', '">', thetext)
 
     # delete empty captions  (delete the next line if you want to keep them)
-    thetext = re.sub('\s*<caption>\s*</caption>\s*', '', thetext)
+#    thetext = re.sub('\s*<caption>\s*</caption>\s*', '', thetext)
 
     return thetext
 
-def mbx_fix(text):   # schmidt calc 3 temporary
+def mbx_fix(text):   # schmidt calc 3 temporarily
 
 
     thetext = text


### PR DESCRIPTION
On the "first time" substitution, the closing "/>" on the empty element image tag was copied, whereas the intent was to remove the front slash, then include the description before the </image>.
I also commented out the line to remove the empty caption.