### PR TITLE
Recursive Conversions

### DIFF
--- a/ltol.py
+++ b/ltol.py
@@ -20,7 +20,7 @@ conversion_options = ["xml", "mbx", "ptx_pp", "mbx_pp", "ptx_fix", "mbx_strict_t
                       "tex", "tex_ptx",
                       "html",
                       "pgtombx"]
-if sys.argv[1] == '-h'
+if sys.argv[1] == "-h"
     print 'To convert a file to a different form, do either:'
     print './ltol.py filetype_plus inputfile outputfile'
     print 'to convert one file, or'

--- a/ltol.py
+++ b/ltol.py
@@ -4,6 +4,7 @@ import sys
 import re
 import os
 import glob
+import shutil
 
 import component
 import transforms
@@ -19,8 +20,21 @@ conversion_options = ["xml", "mbx", "ptx_pp", "mbx_pp", "ptx_fix", "mbx_strict_t
                       "tex", "tex_ptx",
                       "html",
                       "pgtombx"]
+if sys.argv[1] == '-h'
+    print 'To convert a file to a different form, do either:'
+    print './ltol.py filetype_plus inputfile outputfile'
+    print 'to convert one file, or'
+    print './ltol.py filetype_plus inputdirectory outputdirectory'
+    print 'to convert all the "filetype" files in a directory.  The outputdirectory must already exist.'
+    print 'OR if you wish to convert an entire folder and subfolders'
+    print './ltol.py filetype_plus inputrootdir outputrootdir R'
+    print 'For recursion target directory should NOT already exist'
+    print 'Supported filetype_plus: '
+    print conversion_options
+    sys.exit()
 
-if not len(sys.argv) == 4:
+
+if not len(sys.argv) >= 4:
     print 'To convert a file to a different form, do either:'
     print './ltol.py filetype_plus inputfile outputfile'
     print 'to convert one file, or'
@@ -30,9 +44,15 @@ if not len(sys.argv) == 4:
     print conversion_options
     sys.exit()
 
-component.filetype_plus = sys.argv[1]
-component.inputname = sys.argv[2]
-component.outputname = sys.argv[3]
+if len(sys.argv) == 4:
+    component.filetype_plus = sys.argv[1]
+    component.inputname = sys.argv[2]
+    component.outputname = sys.argv[3]
+else:
+    component.filetype_plus = sys.argv[1]
+    component.inputname = sys.argv[2]
+    component.outputname = sys.argv[3]
+    dorecursive = True    
 
 print component.inputname
 print component.outputname
@@ -71,20 +91,34 @@ elif os.path.isdir(component.inputname) and os.path.isdir(component.outputname):
         fileextension_out = component.filetype_plus
 
     print "looking for", fileextension_in, "files in",  component.inputname
-    inputdir = component.inputname
-    inputdir = re.sub(r"/*$","",inputdir)  # remove trailing slash
-    outputdir = component.outputname
-    outputdir = re.sub(r"/*$","",outputdir)  # remove trailing slash
-    outputdir = outputdir + "/"              # and then put it back
-    thefiles = glob.glob(inputdir + "/*." + fileextension_in)
+    if not dorecursive:
+        print "Only looking in", component.inputname
+        inputdir = component.inputname
+        inputdir = re.sub(r"/*$","",inputdir)  # remove trailing slash
+        outputdir = component.outputname
+        outputdir = re.sub(r"/*$","",outputdir)  # remove trailing slash
+        outputdir = outputdir + "/"              # and then put it back
+        thefiles = glob.glob(inputdir + "/*." + fileextension_in)
+    elif dorecursive:
+        #First copy the entire src directory to the new destination.
+        shutil.copytree(component.inputname, component.outputname)
+        thefiles = []
+        #Two loops below walk entire sub-structure and adds full path to 
+        #each file to be converted. Conversion is done in-place (in = out).
+        for root, dirnames, filenames in os.walk(component.outputname):
+            for filename in fnmatch.filter(filenames,'*.'+fileextension_in):
+                thefiles.append([os.path.join(root,filename), os.path.join(root,filename)])
+        
     print "thefiles", thefiles
-    for inputfilename in thefiles:
-        outputfilename = re.sub(".*/([^/]+)", outputdir + r"\1", inputfilename)
-        if fileextension_in != fileextension_out:
-            outputfilename = re.sub(fileextension_in + "$", fileextension_out, outputfilename)
-        if inputfilename == outputfilename:
-            print "big problem, quitting"
-        component.iofilepairs.append([inputfilename, outputfilename])
+    #In recursive version, does conversion in-place.
+    if not dorecursive:
+        for inputfilename in thefiles:
+            outputfilename = re.sub(".*/([^/]+)", outputdir + r"\1", inputfilename)
+            if fileextension_in != fileextension_out:
+                outputfilename = re.sub(fileextension_in + "$", fileextension_out, outputfilename)
+            if inputfilename == outputfilename:
+                print "big problem, quitting"
+            component.iofilepairs.append([inputfilename, outputfilename])
   #  print thefiles
   #  print inputdir 
   #  print component.iofilepairs
@@ -100,11 +134,14 @@ print "about to loop over files:", component.iofilepairs
 
 for inputfile, outputfile in component.iofilepairs:
 
-    # hack for windows
-    inputfile = re.sub(r"\\\\", "/", inputfile)
-    inputfile = re.sub(r"\\", "/", inputfile)
-    outputfile = re.sub(r"\\\\", "/", outputfile)
-    outputfile = re.sub(r"\\", "/", outputfile)
+    #By using os.path.join, the paths SHOULD match the operating systems' 
+    #correct syntax. Regardless of windows or linux. Thank you compiler!
+    if not dorecursive:
+        # hack for windows
+        inputfile = re.sub(r"\\\\", "/", inputfile)
+        inputfile = re.sub(r"\\", "/", inputfile)
+        outputfile = re.sub(r"\\\\", "/", outputfile)
+        outputfile = re.sub(r"\\", "/", outputfile)
 
     component.extra_macros = []
 


### PR DESCRIPTION
This implements a recursive file conversion option. If you test it, I believe you could actually replace the non-recursive (i.e. single folder) with the recursive version and have identical behavior (it's just recursing over one folder). 

Note that this REQUIRES the new directory to NOT EXIST. It has to do with the utility I used to copy the full sub-directory. This reduces the confusion/difficulty in finding the correct, modified file paths for converting. 