### PR TITLE
Fix fatal error due to undefined fileextension_in

### DIFF
--- a/ltol.py
+++ b/ltol.py
@@ -92,8 +92,6 @@ if component.filetype_plus in ["ptx", "ptx_pp", "ptx_permid", "ptx_fix", "ptx_se
 elif component.filetype_plus in ["mbx_pp"]:
     fileextension_in = "mbx"
     fileextension_out = "ptx"
-elif component.filetype_plus in ["xml", "xml_pp", "xml_permid"]:
-    fileextension_out = "mbx"
 elif component.filetype_plus in ["xml", "xml_pp", "xml_permid", "xml_semantic"]:
     fileextension_in = "xml"
     fileextension_out = "xml"


### PR DESCRIPTION
The deleted stanza leads to a fatal error, since `fileextension_in` is not defined after this condition is hit.

I'm guessing there was an editing mistake when `xml_semantic` was added?

Seems to run just fine now, but maybe the fix is different - small amount of speculation here.
